### PR TITLE
Add notes for episodes 1, 77

### DIFF
--- a/episode-0001/README.md
+++ b/episode-0001/README.md
@@ -1,0 +1,15 @@
+# Episode 1: Apr 21, 2015
+
+## Links
+* [Watch this episode on YouTube](https://www.youtube.com/watch?v=nCOeefQpg58)
+* [Blog post on this episode](https://mikeconley.ca/blog/2015/02/16/the-joy-of-coding-episode-1/)
+* [Episode notes on Evernote](https://www.evernote.com/l/AbIzumEhFI9LBpM8iNGUuXLqVAFeiEkn1gg)
+
+## Topics
+
+* [Bug 1090439](https://bugzilla.mozilla.org/show_bug.cgi?id=1090439)
+* e10s windows, printing on Linux.
+* Event loops, nested event loops
+* Spinning an event loop in nsXULWindow and NS_ProcessNextEvent
+* Looking up cause of some error messaging. Look up the string in dxr, get the identifier, find where that identifier is used.
+* Attaching a debugger, setting breakpoint at some known function

--- a/episode-0077/README.md
+++ b/episode-0077/README.md
@@ -1,0 +1,14 @@
+# Episode 77: Oct 26, 2016
+
+## Links
+* [Watch this episode on air.mo](https://air.mozilla.org/the-joy-of-coding-episode-77/)
+* [Episode notes on Evernote](https://www.evernote.com/l/AbI3t2rIi1ZInpfbGLVqugviVSdE8qX3jQs)
+
+## Topics
+
+* [Bug 1300784](https://bugzilla.mozilla.org/show_bug.cgi?id=1300784)  - Combine e10s and non-e10s &lt;select&gt; dropdown mechanisms
+* Debugging using gdb,
+* Debugging focus-ish bugs using a VM, ssh into VM to debug
+* Using [rr](http://rr-project.org/)
+* Using Math.sin/Math.cos as a way to isolate/quickly find some js in rr
+* Event management, active event manager, passing management across frames.


### PR DESCRIPTION
Notes I had from a couple of episodes. Not comprehensive, just what I had. 
We could also copy the evernote notes in here, that's really your call as to where you want the canonical source to be. 
Note that episode 1 wasnt working for me on air.mo, so I linked youtube instead. Ideally we'd have direct links for each note/topic to the timestamp in the video, but just knowing the topics/techniques/details covered is a start. 