### PR TITLE
Bugfix: double slash in url

### DIFF
--- a/_includes/list-episodes.html
+++ b/_includes/list-episodes.html
@@ -16,7 +16,7 @@
   {% endif %}
  
   <li>
-    <a href="{{site.baseurl}}/{{ episode.url }}">
+    <a href="{{ episode.url | relative_url }}">
       Episode {{ episode.number }} - {{ episode.date | date: "%b %d, %Y" }}
     </a>
   </li>


### PR DESCRIPTION
**Step to reproduce**

1. Open https://mikeconley.github.io/joy-of-coding-episode-guide/
2. Go to any episode
3. URL has a double slash in it (e.g. https://mikeconley.github.io/joy-of-coding-episode-guide//episodes/0182/index.html)

**Note**

Using `relative_url`[1] instead of `{{ base.url}}/{{ episode.url}}` resolve this issue.

[1] Relative URL: Prepend the baseurl value to the input. (From [Jekyll Doc](https://jekyllrb.com/docs/liquid/filters/))